### PR TITLE
Remove encoding in xml parser

### DIFF
--- a/asc2mb/asc2mb.py
+++ b/asc2mb/asc2mb.py
@@ -221,7 +221,7 @@ def main(
 
     """
     # mytree = ET.parse(xml_file)
-    parser = etree.XMLParser(encoding="UTF-8")
+    parser = etree.XMLParser()
     mytree = etree.parse(xml_file, parser)
 
     myroot = mytree.getroot()


### PR DESCRIPTION
aSc on windows exports xml in local encoding like `gb2312` or `windows-1252` instead of `UTF-8`. This would make asc2mb fail.

By removing `encoding` option, the xml parser would automatically read the encoding so it would work for all cases.